### PR TITLE
Added an argument to generate script for generating unfoldingWord texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ A bible software that runs the [unfoldingWord](http://unfoldingword.org) Bibles 
 
 ### Building The unfoldingWord Bibles ###
 
-1. Delete all the files (except the README.md) in the `app/content/texts` directory.
-2. Navigate to the `/tools/textgenerator` folder.
-3. Run `node generate.js -a` (`-a` will build every version `input` folder, run without `-a` to see help)
-4. Run `node create_texts_index.js` (this creates a list of all versions to startup the app)
+1. Navigate to the `/tools/textgenerator` folder.
+2. Run `node generate.js -u` (`-u` will build every version that belongs to unfoldingWord in the `input` folder, run without `-u` to see help)
+3. Run `node create_texts_index.js` (this creates a list of all versions to startup the app)
 
 ### Adding Bibles/Texts ###
 

--- a/tools/textgenerator/generate.js
+++ b/tools/textgenerator/generate.js
@@ -361,11 +361,10 @@ if (Object.keys(argv).length == 1) {
 				'-v VERSION,VERSION = only some versions\n' +
 				'-e VERSION,VERSION = exclude some versions\n' +
 				'-a = process all versions\n' +
+				'-u = process all versions that belong to unfoldingWord\n' +
 				'-i = create index\n');
 	return;
 }
-
-
 
 if (argv['i']) {
 	createIndex = true;
@@ -406,6 +405,17 @@ if (argv['a']) {
 	folders.forEach(function(folder) {
 		convertFolder(baseInput + '/' + folder);
 	});
+} else if (typeof argv['u'] != 'undefined') {
+	var directories = getDirectories(baseInput);
+	var filtered = directories.filter(function(el) {
+		return el.substring(0, 3) == 'uw_';
+	});
+	for (var f in filtered) {
+		var folder = filtered[f];
+		var inputPath = path.join(baseInput, folder);
+		
+		convertFolder(inputPath);
+	}
 }
 
 process.exit();


### PR DESCRIPTION
only

https://github.com/unfoldingWord-dev/uw-web/issues/20

Fixes #20. Added the -u argument for the generate script, so it only generates the
unfoldingWord documents, and no other bibles.  This will make it more
efficent in the long run.
