### PR TITLE
John 3 16 ulb bug

### DIFF
--- a/tools/textgenerator/node_modules/unfolding-word/uw-generate-usfm.js
+++ b/tools/textgenerator/node_modules/unfolding-word/uw-generate-usfm.js
@@ -183,6 +183,13 @@ var uwGenerateUsfm = function() {
      * @type {Array}
      */
     var chapterCodes = [];
+    /**
+     * A set of keys that you do not need to care about the next line in the document
+     *
+     * @type {Array}
+     */
+    var skipAheadKeys = ['', 'add', 'add*', 'wj', 'wj*', 'x', 'x*', 'f', 'f*', 'qs', 'ft', 'bk', 'fqa'];
+
     var usfmFiles = fileSystem.readdirSync(inputBasePath);
 
     bibleData.aboutHtml = getAboutContent();
@@ -224,6 +231,12 @@ var uwGenerateUsfm = function() {
         var line = lines[i];
         var usfmLineData = usfmParser.parseLine(line);
         if (usfmLineData.length === 0) {
+          if (line.replace(/\s/g, '').length) {
+            /**
+             * If the line has text, but there is no usfm tag then it should be added to the current text for the chapter.
+             */
+            currentChapter.html += ' '+line;
+          }
           /**
            * We have no data for the line so move on
            */
@@ -236,7 +249,6 @@ var uwGenerateUsfm = function() {
          */
         for (var ud = 0; ud < usfmLineData.length; ud++) {
           var usfmData = usfmLineData[ud];
-
           switch (usfmData.key) {
             case 'b':
               /**

--- a/tools/textgenerator/node_modules/unfolding-word/uw-generate-usfm.js
+++ b/tools/textgenerator/node_modules/unfolding-word/uw-generate-usfm.js
@@ -183,13 +183,6 @@ var uwGenerateUsfm = function() {
      * @type {Array}
      */
     var chapterCodes = [];
-    /**
-     * A set of keys that you do not need to care about the next line in the document
-     *
-     * @type {Array}
-     */
-    var skipAheadKeys = ['', 'add', 'add*', 'wj', 'wj*', 'x', 'x*', 'f', 'f*', 'qs', 'ft', 'bk', 'fqa'];
-
     var usfmFiles = fileSystem.readdirSync(inputBasePath);
 
     bibleData.aboutHtml = getAboutContent();

--- a/tools/textgenerator/tests/support/usfm_test_files/john_3_16_ulb_bug/43-JHN.usfm
+++ b/tools/textgenerator/tests/support/usfm_test_files/john_3_16_ulb_bug/43-JHN.usfm
@@ -1,0 +1,14 @@
+\id JHN Unlocked Literal Bible
+\ide UTF-8
+\h John 
+\toc1 The Gospel According to St. John 
+\toc2 John 
+\toc3 Jhn 
+\mt The Gospel According to Saint John 
+
+\s5
+\c 1
+\p
+\v 16 For God so loved the world, that he gave his only unique Son, that whoever believes in him should not perish but
+have everlasting life.
+\v 17 For God did not send the Son into the world to condemn the world, but so that the world should be saved through him.

--- a/tools/textgenerator/tests/unit/uw-generate-usfm.test.js
+++ b/tools/textgenerator/tests/unit/uw-generate-usfm.test.js
@@ -543,6 +543,24 @@ describe('uwGenerateUsfm', function() {
 
     });
 
+    describe("Bug Fixes", function() {
+      /**
+       * If you look at John 3:16 on the web site, you will see it ends with "should not perish but" leaving off the rest. 
+       * I believe the problem is line breaks in the usfm not being rendered correctly. Like html, line breaks in verses 
+       * that are not part of a \q poetry section should be treated as spaces.
+       *
+       * @author Johnathan Pulos <johnathan@missionaldigerati.org>
+       */
+      it("should correctly render John 3 v 16 in the ULB Bible", function() {
+        var inputBasePath = path.join(testFilePath, 'john_3_16_ulb_bug');
+        var result = uw.generate(inputBasePath, baseInfoJson, true, function(){}, function() {});
+        var c = cheerio.load(result.chapterData[0].html);
+        var sixteenText = c('span.JN1_16').first().text();
+        sixteenText.should.equal('For God so loved the world, that he gave his only unique Son, that whoever believes in him should not perish but have everlasting life.');
+      });
+
+    });
+
   });
 
 


### PR DESCRIPTION
Bug Fix: John 3 v 16 ULB line breaks in verses were not being rendered properly

In the ULB version,  verses followed by line breaks and additional text, the additional text was being ignored.  The parser needed to be updated so that it rightly handled lines with text but no USFM tag.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/uw-web/30)

<!-- Reviewable:end -->
