### PR TITLE
Get language data from the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
 tools/textgenerator/ftp-config.js
 tools/textgenerator/input/
-tools/textgenerator/node_modules
+tools/textgenerator/node_modules/*
+!tools/textgenerator/node_modules/*.js
+!tools/textgenerator/node_modules/unfolding-word
 tools/utilities/
 tools/_old/
 content/texts/
 build/
-app/content/texts/
+app/content/texts/*
 !app/content/texts/README.md
 .idea
+*.iml
 .DS_Store
 npm-debug.log

--- a/tools/textgenerator/node_modules/unfolding-word/uw-grab-available-texts.js
+++ b/tools/textgenerator/node_modules/unfolding-word/uw-grab-available-texts.js
@@ -33,13 +33,7 @@ var uwGrabAvailableTexts = function() {
    * @access private
    */
   var del = require('del');
-  /**
-   * Nodejs package country-language for finding country language data
-   *
-   * @type {Object}
-   * @access private
-   */
-  var countryLanguage = require('country-language');
+
   /**
    * Nodejs package filesystem for writing files
    *
@@ -76,12 +70,53 @@ var uwGrabAvailableTexts = function() {
    * @access public
    */
   uwObject.catalogUrl = '';
+
+  /**
+   * The API url to grab the list of languages from.  It should return JSON.
+   *
+   * @type {String}
+   * @access public
+   */
+  uwObject.languagesUrl = 'http://td.unfoldingword.org/exports/langnames.json';
+
   /**
    * Quiet the notifications produced by this script.  Does not silence errors.
    *
    * @type {Boolean}
    */
   uwObject.silenceNotification = false;
+
+  /**
+   * The list of languages downloaded from the API.
+   *
+   * @type {Array}
+   * @access public
+   */
+  uwObject.languageData = [];
+
+  /**
+   * Get the list of languages from the API.
+   * @param {function} _callback What to do after we've gotten the list
+   */
+  uwObject.downloadLanguageData = function(_callback) {
+
+    display('Getting the list of languages from ' + uwObject.languagesUrl + '.');
+    request(uwObject.languagesUrl, function(error, response, body) {
+      if (error) {
+        display('Error - downloadLanguageData:', true);
+        console.log(error);
+      }
+      else if (response.statusCode != 200) {
+        display('Error - downloadLanguageData: status code = ' + response.statusCode, true);
+        display(body);
+      }
+      else {
+        uwObject.languageData = JSON.parse(body);
+        _callback();
+      }
+    });
+  };
+
   /**
    * Grab the current Bibles from the latest Unfolding Word catalog feed.  Once the content is received,
    * we pass it to the given callback() function with an array of bibles available formated for easier
@@ -173,11 +208,14 @@ var uwGrabAvailableTexts = function() {
    */
   uwObject.process = function() {
     prepareFolder(function () {
-      uwObject.getBibles(function(bibles) {
-        uwObject.downloadBibles(bibles);
+      uwObject.downloadLanguageData(function() {
+        uwObject.getBibles(function(bibles) {
+          uwObject.downloadBibles(bibles);
+        });
       });
     });
   };
+
   function createAboutFile(version) {
     content = '<dt>Information</dt><dd>' + version.name + '</dd>';
     if (version.status.contributors) {
@@ -208,7 +246,7 @@ var uwGrabAvailableTexts = function() {
    * A shortcut function for sending your message to the terminal
    *
    * @param  {String} msg The message to display
-   * @param {Boolean} isError Is this an error?
+   * @param {Boolean} [isError] Is this an error?
    *
    * @return {void}
    * @access private
@@ -257,6 +295,25 @@ var uwGrabAvailableTexts = function() {
     }
     return files;
   }
+
+  /**
+   * Find the language data from the language code
+   * @param lang_code string
+     */
+  function getLanguageData(lang_code) {
+
+    var found = uwObject.languageData.filter(function(lang) {
+      return lang['lc'] == lang_code;
+    });
+
+    if (found.length == 1) {
+        return found[0]
+    }
+
+    // not found
+    return null;
+  }
+
   /**
    * Iterates over the versions of the Bible in a specific language provided by the catalogUrl, and returns an
    * array of objects with each version.
@@ -289,24 +346,23 @@ var uwGrabAvailableTexts = function() {
    */
   function getBibleVersions(languages) {
     var bibleVersions = [];
+    var langCode;
     for (var l = 0; l < languages.length; l++) {
       if(languages[l].lc.indexOf('-') > -1) {
         /**
          * Unique languages with a dash in them
          */
-        var langCode = languages[l].lc.split('-')[0];
+        langCode = languages[l].lc.split('-')[0];
       } else {
-        var langCode = languages[l].lc;
+        langCode = languages[l].lc;
       }
-      var languageData = {};
 
-      countryLanguage.getLanguage(langCode, function(error, language) {
-        if (error) {
-
-        } else {
-          languageData = language;
-        }
-      });
+      // get the information for this language
+      var languageData = getLanguageData(langCode);
+      if (!languageData) {
+        display('Error - getBibleVersions, Language not found: ' + langCode, true);
+        continue;
+      }
 
       var versions = languages[l].vers;
       for (var i = 0; i < versions.length; i++) {
@@ -322,10 +378,10 @@ var uwGrabAvailableTexts = function() {
           abbr:             version.slug.toUpperCase(),
           name:             version.name,
           nameEnglish:      '',
-          lang:             languageData.iso639_3,
-          langName:         languageData.nativeName[0],
-          langNameEnglish:  languageData.name[0],
-          dir:              languageData.direction.toLowerCase(),
+          lang:             languageData['lc'],
+          langName:         languageData['ln'],
+          langNameEnglish:  languageData['ang'],
+          dir:              languageData['ld'],
           generator:        'unfolding-word/uw-generate-usfm',
           checking_level:   checkingLevel
         };


### PR DESCRIPTION
Previously we were using a node library to get the language data for a particular language code, but it does not contain all the languages we need. Specifically it does not contain the `lpx` language code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/uw-web/37)

<!-- Reviewable:end -->
